### PR TITLE
v0.2: Use #[coverage(off)] instead of #[no_coverage]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,10 @@ jobs:
       - run: cargo minimal-versions build --workspace --no-private --all-features
       - run: cargo llvm-cov --text --fail-under-lines 80
         working-directory: tests/basic
-      - run: cargo llvm-cov --text --fail-under-lines 100
-        working-directory: tests/basic
-        if: startsWith(matrix.rust, 'nightly')
+      # TODO: https://github.com/rust-lang/rust/pull/114656 not yet released
+      # - run: cargo llvm-cov --text --fail-under-lines 100
+      #   working-directory: tests/basic
+      #   if: startsWith(matrix.rust, 'nightly')
 
   miri:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+**Note:** coverage-helper 0.2 supports `#[coverage(off)]`.
+See coverage-helper 0.1 for versions that support `#[no_coverage]`.
+
+- Use [`#[coverage(off)]`](https://github.com/rust-lang/rust/pull/114656) instead of `#[no_coverage]`. ([#4](https://github.com/taiki-e/coverage-helper/pull/4))
+
 ## [0.1.1] - 2023-09-13
 
 - Prepare for [renaming of `#[no_coverage]` in future nightly](https://github.com/rust-lang/rust/pull/114656). ([#3](https://github.com/taiki-e/coverage-helper/pull/3))

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 <!-- tidy:crate-doc:start -->
 Helper for <https://github.com/taiki-e/cargo-llvm-cov/issues/123>.
 
-**Note:** coverage-helper 0.1 supports `#[no_coverage]`.
-See coverage-helper 0.2 or later for versions that support `#[coverage(off)]`.
+**Note:** coverage-helper 0.2 supports `#[coverage(off)]`.
+See coverage-helper 0.1 for versions that support `#[no_coverage]`.
 
 ## Usage
 
@@ -24,7 +24,7 @@ coverage-helper = "0.1"
 And add this to your crate root (`lib.rs` or `main.rs`):
 
 ```rust
-#![cfg_attr(coverage_nightly, feature(no_coverage))]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 ```
 
 ## Examples
@@ -41,7 +41,7 @@ fn my_test() {
 Expanded to:
 
 ```rust
-#[cfg_attr(coverage_nightly, no_coverage)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 #[::core::prelude::v1::test]
 fn my_test() {
     // ...

--- a/build.rs
+++ b/build.rs
@@ -5,8 +5,8 @@ use std::{
 };
 
 fn main() {
-    if probe_feature("no_coverage").unwrap_or(false) {
-        println!("cargo:rustc-cfg=coverage_helper_has_no_coverage")
+    if probe_feature("coverage_attribute").unwrap_or(false) {
+        println!("cargo:rustc-cfg=coverage_helper_has_coverage_attribute")
     }
 }
 
@@ -42,7 +42,7 @@ fn probe_feature(feature_name: &str) -> Option<bool> {
     let mut child = cmd.spawn().ok()?;
     let mut stdin = child.stdin.take().expect("rustc stdin");
 
-    // There is no need to respect TARGET since no_coverage is platform-independent,
+    // There is no need to respect TARGET since #[coverage] is platform-independent,
     // just check for host. And host always has std.
     stdin
         .write_all(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@
 <!-- tidy:crate-doc:start -->
 Helper for <https://github.com/taiki-e/cargo-llvm-cov/issues/123>.
 
-**Note:** coverage-helper 0.1 supports `#[no_coverage]`.
-See coverage-helper 0.2 or later for versions that support `#[coverage(off)]`.
+**Note:** coverage-helper 0.2 supports `#[coverage(off)]`.
+See coverage-helper 0.1 for versions that support `#[no_coverage]`.
 
 ## Usage
 
@@ -17,7 +17,7 @@ coverage-helper = "0.1"
 And add this to your crate root (`lib.rs` or `main.rs`):
 
 ```rust
-#![cfg_attr(coverage_nightly, feature(no_coverage))]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 ```
 
 ## Examples
@@ -34,7 +34,7 @@ fn my_test() {
 Expanded to:
 
 ```rust
-#[cfg_attr(coverage_nightly, no_coverage)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 #[::core::prelude::v1::test]
 fn my_test() {
     // ...
@@ -74,8 +74,8 @@ pub fn test(args: TokenStream, input: TokenStream) -> TokenStream {
             .into_compile_error();
     }
     let mut out = TokenStream::new();
-    if cfg!(coverage_helper_has_no_coverage) {
-        out.extend(quote! { #[cfg_attr(coverage_nightly, no_coverage)] });
+    if cfg!(coverage_helper_has_coverage_attribute) {
+        out.extend(quote! { #[cfg_attr(coverage_nightly, coverage(off))] });
     }
     out.extend(quote! { #[::core::prelude::v1::test] });
     out.extend(input);

--- a/tests/basic/src/lib.rs
+++ b/tests/basic/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(coverage_nightly, feature(no_coverage))]
+// #![cfg_attr(coverage_nightly, feature(coverage_attribute))] // TODO: https://github.com/rust-lang/rust/pull/114656 not yet released
 #![allow(dead_code)]
 
 #[coverage_helper::test]


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/114656 and https://github.com/taiki-e/cargo-llvm-cov/issues/312 for the context.